### PR TITLE
Mute page background colors for better readability

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -157,25 +157,25 @@ caption {
 }
 .pagebg_business {
   background-color: white;
-  background-image: linear-gradient(greenyellow, rgba(174, 188, 140, 0.027));
+  background-image: linear-gradient(rgba(173, 255, 47, 0.4), rgba(174, 188, 140, 0.027));
   color: rgb(2, 85, 23);
   opacity: 1;
 }
 .pagebg_data {
   background-color: white;
-  background-image: linear-gradient(peachpuff, rgba(242, 212, 188, 0.027));
+  background-image: linear-gradient(rgba(255, 218, 185, 0.5), rgba(242, 212, 188, 0.027));
   color: brown;
   opacity: 1;
 }
 .pagebg_application {
   background-color: white;
-  background-image: linear-gradient(aqua, rgba(176, 239, 240, 0.027));
+  background-image: linear-gradient(rgba(0, 255, 255, 0.35), rgba(176, 239, 240, 0.027));
   color: rgb(52, 2, 145);
   opacity: 1;
 }
 .pagebg_technology {
   background-color: white;
-  background-image: linear-gradient(plum, rgba(237, 199, 244, 0.027));
+  background-image: linear-gradient(rgba(221, 160, 221, 0.5), rgba(237, 199, 244, 0.027));
   color: rgba(87, 2, 100, 0.925);
   opacity: 1;
 }


### PR DESCRIPTION
## Summary
- Reduced opacity of page background gradient colors to create softer, less bright backgrounds
- Colors now match navigation buttons but are muted for improved readability

| Page | Before | After |
|------|--------|-------|
| Business | `greenyellow` (100%) | `rgba(173, 255, 47, 0.4)` (40%) |
| Data | `peachpuff` (100%) | `rgba(255, 218, 185, 0.5)` (50%) |
| Application | `aqua` (100%) | `rgba(0, 255, 255, 0.35)` (35%) |
| Technology | `plum` (100%) | `rgba(221, 160, 221, 0.5)` (50%) |

Fixes #17

## Test plan
- [ ] Verify all page backgrounds are visually softer
- [ ] Confirm text remains readable on all pages
- [ ] Check color consistency with navigation buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)